### PR TITLE
Add ObjectImageCleanerLambda for S3 object cleanup

### DIFF
--- a/infra/SceneSplit.Cdk/Constructs/ObjectImageCleanerLambdaConstruct.cs
+++ b/infra/SceneSplit.Cdk/Constructs/ObjectImageCleanerLambdaConstruct.cs
@@ -1,0 +1,57 @@
+﻿using Amazon.CDK;
+using Amazon.CDK.AWS.EC2;
+using Amazon.CDK.AWS.Lambda;
+using Amazon.CDK.AWS.Lambda.EventSources;
+using Amazon.CDK.AWS.S3;
+using Amazon.CDK.AWS.SQS;
+using Constructs;
+using SceneSplit.Configuration;
+
+namespace SceneSplit.Cdk.Constructs;
+
+public class ObjectImageCleanerLambdaConstruct : Construct
+{
+    public Function LambdaFunction { get; }
+
+    public ObjectImageCleanerLambdaConstruct(
+        Construct scope,
+        string id,
+        Vpc vpc,
+        Bucket objectBucket)
+        : base(scope, id)
+    {
+        var lambdaSecurityGroup = new SecurityGroup(this, "ObjectImageCleanerLambdaSecurityGroup", new SecurityGroupProps
+        {
+            AllowAllOutbound = true,
+            Vpc = vpc
+        });
+        var failureQueue = new Queue(this, "ObjectImageCleanerLambdaFailures");
+
+        LambdaFunction = new Function(this, "ObjectImageCleanerLambda", new FunctionProps
+        {
+            FunctionName = "object-image-cleaner-lambda",
+            Runtime = Runtime.DOTNET_8,
+            Handler = "SceneSplit.ObjectImageCleanerLambda::SceneSplit.ObjectImageCleanerLambda.Function::Handler",
+            Code = Code.FromAsset("lambda-publish/SceneSplit.ObjectImageCleanerLambda.zip"),
+            Timeout = Duration.Seconds(30),
+            MemorySize = 128,
+            Vpc = vpc,
+            SecurityGroups = [lambdaSecurityGroup],
+            Environment = new Dictionary<string, string>
+            {
+                { "DOTNET_ENVIRONMENT", "Production" },
+                { ObjectImageCleanerLambdaConfigurationKeys.MAX_KEYS_SEARCH_CONCURENCY, 16.ToString() },
+                { ObjectImageCleanerLambdaConfigurationKeys.MAX_DELETE_BRANCH, 1000.ToString() },
+            },
+            DeadLetterQueue = failureQueue,
+            DeadLetterQueueEnabled = true
+        });
+
+        LambdaFunction.AddEventSource(new S3EventSource(objectBucket, new S3EventSourceProps
+        {
+            Events = [EventType.OBJECT_CREATED],
+        }));
+
+        objectBucket.GrantReadWrite(LambdaFunction);
+    }
+}

--- a/infra/SceneSplit.Cdk/SceneSplitStack.cs
+++ b/infra/SceneSplit.Cdk/SceneSplitStack.cs
@@ -99,7 +99,14 @@ public class SceneSplitStack : Stack
             vpc,
             sceneImageBucket,
             sceneImageDetectedObjectsQueue
-       );
+        );
+
+        _ = new ObjectImageCleanerLambdaConstruct(
+            this,
+            "ObjectImageCleanerLambdaConstruct",
+            vpc,
+            detectedObjectImageBucket
+        );
 
         var apiEndpoint = $"http://{apiService.FargateService.LoadBalancer.LoadBalancerDnsName}";
         _ = new FrontendServiceConstruct(this, "FrontendServiceConstruct", cluster, vpc, apiEndpoint);

--- a/infra/SceneSplit.Lambdas.Package/SceneSplit.Lambdas.Package.csproj
+++ b/infra/SceneSplit.Lambdas.Package/SceneSplit.Lambdas.Package.csproj
@@ -18,6 +18,11 @@
 		  WorkingDirectory='..\..\src\SceneSplit.Backend\SceneSplit.ObjectImageSearchLambda'
 		  ConsoleToMSBuild='true' />
 
+		<Exec
+		  Command='dotnet lambda package --configuration $(Configuration) --framework $(Framework) --verbose --output-package "$(PublishDir)\SceneSplit.ObjectImageCleanerLambda.zip"'
+		  WorkingDirectory='..\..\src\SceneSplit.Backend\SceneSplit.ObjectImageCleanerLambda'
+		  ConsoleToMSBuild='true' />
+
 	</Target>
 
 </Project>

--- a/src/SceneSplit.Backend/SceneSplit.Backend.sln
+++ b/src/SceneSplit.Backend/SceneSplit.Backend.sln
@@ -62,6 +62,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SceneSplit.ObjectImageSearc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SceneSplit.ObjectImageSearchLambda.UnitTests", "..\..\tests\SceneSplit.ObjectImageSearchLambda.UnitTests\SceneSplit.ObjectImageSearchLambda.UnitTests.csproj", "{DF98EDD4-B597-41D8-A4D6-16658D2B66CC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SceneSplit.ObjectImageCleanerLambda", "SceneSplit.ObjectImageCleanerLambda\SceneSplit.ObjectImageCleanerLambda.csproj", "{5263E201-941C-48F5-985D-702526A9242A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SceneSplit.ObjectImageCleanerLambda.UnitTests", "..\..\tests\SceneSplit.ObjectImageCleanerLambda.UnitTests\SceneSplit.ObjectImageCleanerLambda.UnitTests.csproj", "{EBEB5120-3E95-4B4F-9677-40FFC190A373}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -132,6 +136,14 @@ Global
 		{DF98EDD4-B597-41D8-A4D6-16658D2B66CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF98EDD4-B597-41D8-A4D6-16658D2B66CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DF98EDD4-B597-41D8-A4D6-16658D2B66CC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5263E201-941C-48F5-985D-702526A9242A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5263E201-941C-48F5-985D-702526A9242A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5263E201-941C-48F5-985D-702526A9242A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5263E201-941C-48F5-985D-702526A9242A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBEB5120-3E95-4B4F-9677-40FFC190A373}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBEB5120-3E95-4B4F-9677-40FFC190A373}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBEB5120-3E95-4B4F-9677-40FFC190A373}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBEB5120-3E95-4B4F-9677-40FFC190A373}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -157,6 +169,8 @@ Global
 		{46F4CC6B-836F-68FF-A0D1-7F5DC2838876} = {F9804709-4F1A-4666-A5F8-FE762AFAFA81}
 		{11CBD9A1-55EE-4B84-A8A2-AF7E3AE675CF} = {F9804709-4F1A-4666-A5F8-FE762AFAFA81}
 		{DF98EDD4-B597-41D8-A4D6-16658D2B66CC} = {FCA762AF-9535-4BFF-B0F2-A0A1F5A3C76F}
+		{5263E201-941C-48F5-985D-702526A9242A} = {F9804709-4F1A-4666-A5F8-FE762AFAFA81}
+		{EBEB5120-3E95-4B4F-9677-40FFC190A373} = {FCA762AF-9535-4BFF-B0F2-A0A1F5A3C76F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EEF3F48B-173E-4436-9539-B95BA6E6C5EA}

--- a/src/SceneSplit.Backend/SceneSplit.Configuration/ConfigurationKeys.cs
+++ b/src/SceneSplit.Backend/SceneSplit.Configuration/ConfigurationKeys.cs
@@ -48,3 +48,9 @@ public static class ObjectImageSearchLambdaConfigurationKeys
     public static string RESIZE_HEIGHT { get; } = nameof(RESIZE_HEIGHT);
     public static string IMAGE_QUALITY_COMPRESSION { get; } = nameof(IMAGE_QUALITY_COMPRESSION);
 }
+
+public static class ObjectImageCleanerLambdaConfigurationKeys
+{
+    public static string MAX_KEYS_SEARCH_CONCURENCY { get; } = nameof(MAX_KEYS_SEARCH_CONCURENCY);
+    public static string MAX_DELETE_BRANCH { get; } = nameof(MAX_DELETE_BRANCH);
+}

--- a/src/SceneSplit.Backend/SceneSplit.ObjectImageCleanerLambda/.lambda-test-tool/SavedRequests/s3-clean.json
+++ b/src/SceneSplit.Backend/SceneSplit.ObjectImageCleanerLambda/.lambda-test-tool/SavedRequests/s3-clean.json
@@ -1,0 +1,38 @@
+{
+  "Records": [
+    {
+      "eventVersion": "2.0",
+      "eventSource": "aws:s3",
+      "awsRegion": "{region}",
+      "eventTime": "1970-01-01T00:00:00Z",
+      "eventName": "ObjectCreated:Put",
+      "userIdentity": {
+        "principalId": "EXAMPLE"
+      },
+      "requestParameters": {
+        "sourceIPAddress": "127.0.0.1"
+      },
+      "responseElements": {
+        "x-amz-request-id": "EXAMPLE123456789",
+        "x-amz-id-2": "EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH"
+      },
+      "s3": {
+        "s3SchemaVersion": "1.0",
+        "configurationId": "testConfigRule",
+        "bucket": {
+          "name": "scene-split-detected-objects",
+          "ownerIdentity": {
+            "principalId": "EXAMPLE"
+          },
+          "arn": "arn:{partition}:s3:::mybucket"
+        },
+        "object": {
+          "key": "858046.jpg",
+          "size": 1024,
+          "eTag": "0123456789abcdef0123456789abcdef",
+          "sequencer": "0A1B2C3D4E5F678901"
+        }
+      }
+    }
+  ]
+}

--- a/src/SceneSplit.Backend/SceneSplit.ObjectImageCleanerLambda/Function.cs
+++ b/src/SceneSplit.Backend/SceneSplit.ObjectImageCleanerLambda/Function.cs
@@ -1,0 +1,189 @@
+﻿using Amazon.Lambda.Core;
+using Amazon.Lambda.S3Events;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Microsoft.Extensions.Logging;
+using SceneSplit.Configuration;
+
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace SceneSplit.ObjectImageCleanerLambda;
+
+public sealed class Function
+{
+    private readonly IAmazonS3 s3Client;
+    private readonly ILogger<Function> logger;
+    private readonly ObjectImageCleanerLambdaOptions options;
+
+    public Function()
+    {
+        var loggerFactory = LoggerFactory.Create(builder => builder.AddLambdaLogger());
+        logger = loggerFactory.CreateLogger<Function>();
+        s3Client = new AmazonS3Client();
+        options = ObjectImageCleanerLambdaOptions.FromEnvironment();
+    }
+
+    public Function(IAmazonS3 s3Client, ILogger<Function> logger, ObjectImageCleanerLambdaOptions options)
+    {
+        this.s3Client = s3Client;
+        this.logger = logger;
+        this.options = options;
+    }
+
+    public async Task Handler(S3Event s3Event)
+    {
+        foreach (var s3Entity in s3Event.Records.Select(r => r.S3))
+        {
+            var bucket = s3Entity.Bucket.Name;
+            var key = s3Entity.Object.Key;
+
+            Log.CleanerTriggered(logger, bucket, key);
+
+            var (userId, workflowIdToKeep) = await GetEventContextAsync(bucket, key);
+            if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(workflowIdToKeep))
+            {
+                Log.SkippingCleanupMissingTags(logger, bucket, key, userId, workflowIdToKeep);
+                continue;
+            }
+
+            Log.StartingCleanup(logger, userId, workflowIdToKeep);
+
+            var (toDelete, scanned) = await EnumerateKeysToDeleteAsync(bucket, key, userId, workflowIdToKeep);
+
+            var deleted = await DeleteKeysAsync(bucket, toDelete);
+
+            Log.CleanupCompleted(logger, userId, scanned, deleted, workflowIdToKeep);
+        }
+    }
+
+    private async Task<(string? UserId, string? WorkflowId)> GetEventContextAsync(string bucket, string key)
+    {
+        var srcTagsResp = await s3Client.GetObjectTaggingAsync(new GetObjectTaggingRequest
+        {
+            BucketName = bucket,
+            Key = key
+        });
+
+        var srcTags = srcTagsResp.Tagging ?? [];
+        var userId = srcTags.FirstOrDefault(t => t.Key == WorkflowTags.USER_ID_TAG)?.Value;
+        var workflowIdToKeep = srcTags.FirstOrDefault(t => t.Key == WorkflowTags.WORKFLOW_ID)?.Value;
+
+        return (userId, workflowIdToKeep);
+    }
+
+    private async Task<(List<string> KeysToDelete, int Scanned)> EnumerateKeysToDeleteAsync(
+        string bucket,
+        string triggeringKey,
+        string userId,
+        string workflowIdToKeep)
+    {
+        var keysToDelete = new List<string>();
+        var scanned = 0;
+        string? continuation = null;
+
+        do
+        {
+            var listResp = await s3Client.ListObjectsV2Async(new ListObjectsV2Request
+            {
+                BucketName = bucket,
+                ContinuationToken = continuation
+            });
+
+            var pageKeys = listResp.S3Objects?.Select(o => o.Key).ToList() ?? [];
+            if (pageKeys.Count == 0)
+            {
+                break;
+            }
+
+            scanned += pageKeys.Count;
+
+            using var throttler = new SemaphoreSlim(options.MaxKeysSearchConcurrency);
+            var tasks = pageKeys.Select(async k =>
+            {
+                if (string.Equals(k, triggeringKey, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                await throttler.WaitAsync();
+                try
+                {
+                    var tagResp = await s3Client.GetObjectTaggingAsync(new GetObjectTaggingRequest
+                    {
+                        BucketName = bucket,
+                        Key = k
+                    });
+
+                    var tags = tagResp.Tagging ?? [];
+                    var uTag = tags.FirstOrDefault(t => t.Key == WorkflowTags.USER_ID_TAG)?.Value;
+                    if (!string.Equals(uTag, userId, StringComparison.Ordinal))
+                    {
+                        return;
+                    }
+
+                    var wfTag = tags.FirstOrDefault(t => t.Key == WorkflowTags.WORKFLOW_ID)?.Value;
+                    if (!string.Equals(wfTag, workflowIdToKeep, StringComparison.Ordinal))
+                    {
+                        lock (keysToDelete)
+                        {
+                            keysToDelete.Add(k);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.FailedToReadTags(logger, ex, bucket, k);
+                }
+                finally
+                {
+                    throttler.Release();
+                }
+            });
+
+            await Task.WhenAll(tasks);
+
+            continuation = listResp.IsTruncated == true ? listResp.NextContinuationToken : null;
+
+        } while (continuation != null);
+
+        return (keysToDelete, scanned);
+    }
+
+    private async Task<int> DeleteKeysAsync(string bucket, List<string> keys)
+    {
+        if (keys.Count == 0)
+        {
+            return 0;
+        }
+
+        var totalDeleted = 0;
+
+        for (var i = 0; i < keys.Count; i += options.MaxDeleteBatch)
+        {
+            var slice = keys.Skip(i).Take(options.MaxDeleteBatch)
+                .Select(k => new KeyVersion { Key = k })
+                .ToList();
+
+            var req = new DeleteObjectsRequest
+            {
+                BucketName = bucket,
+                Objects = slice
+            };
+
+            var resp = await s3Client.DeleteObjectsAsync(req);
+            totalDeleted += slice.Count;
+
+            Log.DeletedBatch(logger, slice.Count, bucket);
+
+            if (resp.DeleteErrors?.Count > 0)
+            {
+                foreach (var err in resp.DeleteErrors)
+                {
+                    Log.DeleteError(logger, err.Key, err.Code, err.Message);
+                }
+            }
+        }
+
+        return totalDeleted;
+    }
+}

--- a/src/SceneSplit.Backend/SceneSplit.ObjectImageCleanerLambda/Log.cs
+++ b/src/SceneSplit.Backend/SceneSplit.ObjectImageCleanerLambda/Log.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace SceneSplit.ObjectImageCleanerLambda;
+
+internal static partial class Log
+{
+    [LoggerMessage(EventId = 5000, Level = LogLevel.Information, Message = "Cleaner triggered for {Bucket}/{Key}")]
+    public static partial void CleanerTriggered(ILogger logger, string bucket, string key);
+
+    [LoggerMessage(EventId = 5001, Level = LogLevel.Warning, Message = "Skipping cleanup for {Bucket}/{Key} due to missing tags. userId='{UserId}', workflowId='{WorkflowId}'")]
+    public static partial void SkippingCleanupMissingTags(ILogger logger, string bucket, string key, string? userId, string? workflowId);
+
+    [LoggerMessage(EventId = 5002, Level = LogLevel.Information, Message = "Starting cleanup. UserId={UserId}, Keep WorkflowId={WorkflowId}")]
+    public static partial void StartingCleanup(ILogger logger, string userId, string workflowId);
+
+    [LoggerMessage(EventId = 5003, Level = LogLevel.Warning, Message = "Failed to read tags for {Bucket}/{Key}. Skipping.")]
+    public static partial void FailedToReadTags(ILogger logger, Exception exception, string bucket, string key);
+
+    [LoggerMessage(EventId = 5004, Level = LogLevel.Information, Message = "Deleted batch of {Count} objects from bucket {Bucket}")]
+    public static partial void DeletedBatch(ILogger logger, int count, string bucket);
+
+    [LoggerMessage(EventId = 5005, Level = LogLevel.Warning, Message = "Delete error: Key={Key}, Code={Code}, Message={Message}")]
+    public static partial void DeleteError(ILogger logger, string key, string code, string message);
+
+    [LoggerMessage(EventId = 5006, Level = LogLevel.Information, Message = "Cleanup completed for UserId={UserId}. Scanned={Scanned}, Deleted={Deleted}, KeptWorkflowId={WorkflowId}")]
+    public static partial void CleanupCompleted(ILogger logger, string userId, int scanned, int deleted, string workflowId);
+}

--- a/src/SceneSplit.Backend/SceneSplit.ObjectImageCleanerLambda/Properties/launchSettings.json
+++ b/src/SceneSplit.Backend/SceneSplit.ObjectImageCleanerLambda/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "Mock Lambda Test Tool": {
+      "commandName": "Executable",
+      "commandLineArgs": "--port 5050",
+      "workingDirectory": ".\\bin\\$(Configuration)\\net8.0",
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-8.0.exe",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/SceneSplit.Backend/SceneSplit.ObjectImageCleanerLambda/SceneAnalysisLambdaOptions.cs
+++ b/src/SceneSplit.Backend/SceneSplit.ObjectImageCleanerLambda/SceneAnalysisLambdaOptions.cs
@@ -1,0 +1,18 @@
+﻿using SceneSplit.Configuration;
+
+namespace SceneSplit.ObjectImageCleanerLambda;
+
+public record ObjectImageCleanerLambdaOptions
+{
+    public int MaxKeysSearchConcurrency { get; init; } = 1000;
+    public int MaxDeleteBatch { get; init; } = 16;
+
+    public static ObjectImageCleanerLambdaOptions FromEnvironment() => new()
+    {
+        MaxKeysSearchConcurrency = int.Parse(Environment.GetEnvironmentVariable(ObjectImageCleanerLambdaConfigurationKeys.MAX_KEYS_SEARCH_CONCURENCY)
+            ?? 1000.ToString()),
+
+        MaxDeleteBatch = int.Parse(Environment.GetEnvironmentVariable(ObjectImageCleanerLambdaConfigurationKeys.MAX_DELETE_BRANCH)
+            ?? 16.ToString()),
+    };
+}

--- a/src/SceneSplit.Backend/SceneSplit.ObjectImageCleanerLambda/SceneSplit.ObjectImageCleanerLambda.csproj
+++ b/src/SceneSplit.Backend/SceneSplit.ObjectImageCleanerLambda/SceneSplit.ObjectImageCleanerLambda.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<RestorePackages>true</RestorePackages>
+		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+		<AWSProjectType>Lambda</AWSProjectType>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<PublishReadyToRun>false</PublishReadyToRun>
+		<RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Amazon.Lambda.Logging.AspNetCore" />
+		<PackageReference Include="Amazon.Lambda.Core" />
+		<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" />
+		<PackageReference Include="Amazon.Lambda.S3Events" />
+		<PackageReference Include="AWSSDK.S3" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\SceneSplit.Configuration\SceneSplit.Configuration.csproj" />
+	</ItemGroup>
+
+
+	<ItemGroup>
+		<InternalsVisibleTo Include="SceneSplit.ObjectImageCleanerLambda.UnitTests" />
+	</ItemGroup>
+</Project>

--- a/src/SceneSplit.Backend/SceneSplit.ObjectImageCleanerLambda/aws-lambda-tools-defaults.json
+++ b/src/SceneSplit.Backend/SceneSplit.ObjectImageCleanerLambda/aws-lambda-tools-defaults.json
@@ -1,0 +1,9 @@
+{
+  "profile": "",
+  "region": "",
+  "configuration": "Release",
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
+  "function-timeout": 30,
+  "function-handler": "SceneSplit.ObjectImageCleanerLambda::SceneSplit.ObjectImageCleanerLambda.Function::Handler"
+}

--- a/tests/SceneSplit.ObjectImageCleanerLambda.UnitTests/FunctionTests.cs
+++ b/tests/SceneSplit.ObjectImageCleanerLambda.UnitTests/FunctionTests.cs
@@ -1,0 +1,311 @@
+﻿using Amazon.Lambda.S3Events;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SceneSplit.Configuration;
+using SceneSplit.TestShared;
+
+namespace SceneSplit.ObjectImageCleanerLambda.UnitTests;
+
+[TestFixture]
+public class FunctionTests
+{
+    private const string Bucket = "bucket-a";
+    private const string TriggerKey = "wf2/img-new.jpg";
+    private const string UserId = "user-123";
+    private const string KeepWorkflow = "wf2";
+
+    private Mock<IAmazonS3> s3Mock;
+    private Mock<ILogger<Function>> loggerMock;
+    private ObjectImageCleanerLambdaOptions options;
+
+    private Function function;
+
+    [SetUp]
+    public void SetUp()
+    {
+        s3Mock = new Mock<IAmazonS3>();
+        loggerMock = TestHelper.CreateLoggerMock<Function>();
+        options = new ObjectImageCleanerLambdaOptions
+        {
+            MaxKeysSearchConcurrency = 8,
+            MaxDeleteBatch = 1000
+        };
+
+        function = new Function(s3Mock.Object, loggerMock.Object, options);
+    }
+
+    private static S3Event CreateEvent((string Bucket, string Key) s3Object)
+    {
+        var s3Entity = new S3Event.S3Entity
+        {
+            Bucket = new S3Event.S3BucketEntity { Name = s3Object.Bucket },
+            Object = new S3Event.S3ObjectEntity { Key = s3Object.Key }
+        };
+
+        var record = new S3Event.S3EventNotificationRecord
+        {
+            S3 = s3Entity
+        };
+
+        return new S3Event
+        {
+            Records = [record]
+        };
+    }
+
+    [Test]
+    public async Task Handler_WhenMissingRequiredTags_SkipsCleanup()
+    {
+        // Arrange
+        var s3Event = CreateEvent((Bucket, TriggerKey));
+
+        s3Mock.Setup(s => s.GetObjectTaggingAsync(
+            It.Is<GetObjectTaggingRequest>(r => r.BucketName == Bucket && r.Key == TriggerKey),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new GetObjectTaggingResponse { Tagging = [] });
+
+        // Act
+        await function.Handler(s3Event);
+
+        // Assert
+        loggerMock.VerifyLog(LogLevel.Information, Times.Once(), nameof(Log.CleanerTriggered));
+        loggerMock.VerifyLog(LogLevel.Warning, Times.Once(), nameof(Log.SkippingCleanupMissingTags));
+
+        s3Mock.Verify(s => s.ListObjectsV2Async(It.IsAny<ListObjectsV2Request>(), It.IsAny<CancellationToken>()), Times.Never);
+        s3Mock.Verify(s => s.DeleteObjectsAsync(It.IsAny<DeleteObjectsRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Handler_DeletesObjectsForSameUser_WithDifferentOrMissingWorkflow()
+    {
+        // Arrange
+        var keysOnBucket = new[]
+        {
+            TriggerKey,
+            "wf1/old-1.jpg",
+            "wf2/keep-1.jpg",
+            "no-wf/missing.jpg",
+            "other-user/ignore.jpg"
+        };
+
+        var s3Event = CreateEvent((Bucket, TriggerKey));
+
+        s3Mock.Setup(s => s.GetObjectTaggingAsync(
+            It.Is<GetObjectTaggingRequest>(r => r.Key == TriggerKey),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new GetObjectTaggingResponse
+        {
+            Tagging =
+            [
+                new Tag { Key = WorkflowTags.USER_ID_TAG, Value = UserId },
+                new Tag { Key = WorkflowTags.WORKFLOW_ID, Value = KeepWorkflow }
+            ]
+        });
+
+        s3Mock.Setup(s => s.ListObjectsV2Async(
+            It.Is<ListObjectsV2Request>(r => r.BucketName == Bucket),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new ListObjectsV2Response
+        {
+            S3Objects = keysOnBucket.Select(k => new S3Object { Key = k }).ToList(),
+            IsTruncated = false
+        });
+
+        s3Mock.Setup(s => s.GetObjectTaggingAsync(
+            It.Is<GetObjectTaggingRequest>(r => r.Key == "wf1/old-1.jpg"),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new GetObjectTaggingResponse
+        {
+            Tagging =
+            [
+                new Tag { Key = WorkflowTags.USER_ID_TAG, Value = UserId },
+                new Tag { Key = WorkflowTags.WORKFLOW_ID, Value = "wf1" }
+            ]
+        });
+
+        s3Mock.Setup(s => s.GetObjectTaggingAsync(
+            It.Is<GetObjectTaggingRequest>(r => r.Key == "wf2/keep-1.jpg"),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new GetObjectTaggingResponse
+        {
+            Tagging =
+            [
+                new Tag { Key = WorkflowTags.USER_ID_TAG, Value = UserId },
+                new Tag { Key = WorkflowTags.WORKFLOW_ID, Value = KeepWorkflow }
+            ]
+        });
+
+        s3Mock.Setup(s => s.GetObjectTaggingAsync(
+            It.Is<GetObjectTaggingRequest>(r => r.Key == "no-wf/missing.jpg"),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new GetObjectTaggingResponse
+        {
+            Tagging =
+            [
+                new Tag { Key = WorkflowTags.USER_ID_TAG, Value = UserId }
+            ]
+        });
+
+        s3Mock.Setup(s => s.GetObjectTaggingAsync(
+            It.Is<GetObjectTaggingRequest>(r => r.Key == "other-user/ignore.jpg"),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new GetObjectTaggingResponse
+        {
+            Tagging =
+            [
+                new Tag { Key = WorkflowTags.USER_ID_TAG, Value = "someone-else" },
+                new Tag { Key = WorkflowTags.WORKFLOW_ID, Value = "wfZ" }
+            ]
+        });
+
+        DeleteObjectsRequest? capturedDelete = null;
+        s3Mock.Setup(s => s.DeleteObjectsAsync(
+                It.IsAny<DeleteObjectsRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<DeleteObjectsRequest, CancellationToken>((req, _) => capturedDelete = req)
+            .ReturnsAsync(new DeleteObjectsResponse());
+
+        // Act
+        await function.Handler(s3Event);
+
+        // Assert
+        Assert.That(capturedDelete, Is.Not.Null);
+        var deletedKeys = capturedDelete!.Objects.Select(o => o.Key).ToHashSet();
+        Assert.That(deletedKeys, Is.EquivalentTo(["wf1/old-1.jpg", "no-wf/missing.jpg"]));
+
+        loggerMock.VerifyLog(LogLevel.Information, Times.Once(), nameof(Log.StartingCleanup));
+        loggerMock.VerifyLog(LogLevel.Information, Times.AtLeastOnce(), nameof(Log.DeletedBatch));
+        loggerMock.VerifyLog(LogLevel.Information, Times.Once(), nameof(Log.CleanupCompleted));
+    }
+
+    [Test]
+    public async Task Handler_WhenTagReadFails_LogsWarningAndContinues()
+    {
+        // Arrange
+        var otherKey = "wf0/error.jpg";
+        var keepKey = "wf2/keep-ok.jpg";
+
+        var s3Event = CreateEvent((Bucket, TriggerKey));
+
+        s3Mock.Setup(s => s.GetObjectTaggingAsync(
+            It.Is<GetObjectTaggingRequest>(r => r.Key == TriggerKey),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new GetObjectTaggingResponse
+        {
+            Tagging =
+            [
+                new Tag { Key = WorkflowTags.USER_ID_TAG, Value = UserId },
+                new Tag { Key = WorkflowTags.WORKFLOW_ID, Value = KeepWorkflow }
+            ]
+        });
+
+        s3Mock.Setup(s => s.ListObjectsV2Async(
+            It.Is<ListObjectsV2Request>(r => r.BucketName == Bucket),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new ListObjectsV2Response
+        {
+            S3Objects =
+            [
+                new() { Key = TriggerKey },
+                new() { Key = otherKey },
+                new() { Key = keepKey }
+            ],
+            IsTruncated = false
+        });
+
+        s3Mock.Setup(s => s.GetObjectTaggingAsync(
+            It.Is<GetObjectTaggingRequest>(r => r.Key == otherKey),
+            It.IsAny<CancellationToken>()))
+        .ThrowsAsync(new Exception("boom"));
+
+        s3Mock.Setup(s => s.GetObjectTaggingAsync(
+            It.Is<GetObjectTaggingRequest>(r => r.Key == keepKey),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new GetObjectTaggingResponse
+        {
+            Tagging =
+            [
+                new Tag { Key = WorkflowTags.USER_ID_TAG, Value = UserId },
+                new Tag { Key = WorkflowTags.WORKFLOW_ID, Value = KeepWorkflow }
+            ]
+        });
+
+        s3Mock.Setup(s => s.DeleteObjectsAsync(
+                It.IsAny<DeleteObjectsRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeleteObjectsResponse());
+
+        // Act
+        await function.Handler(s3Event);
+
+        // Assert
+        loggerMock.VerifyLog(LogLevel.Warning, Times.AtLeastOnce(), nameof(Log.FailedToReadTags));
+        s3Mock.Verify(s => s.DeleteObjectsAsync(It.IsAny<DeleteObjectsRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        loggerMock.VerifyLog(LogLevel.Information, Times.Once(), nameof(Log.CleanupCompleted));
+    }
+
+    [Test]
+    public async Task Handler_LogsDeleteErrors_WhenS3ReturnsErrors()
+    {
+        // Arrange
+        var oldKey = "wf1/old.jpg";
+        var s3Event = CreateEvent((Bucket, TriggerKey));
+
+        s3Mock.Setup(s => s.GetObjectTaggingAsync(
+            It.Is<GetObjectTaggingRequest>(r => r.Key == TriggerKey),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new GetObjectTaggingResponse
+        {
+            Tagging =
+            [
+                new Tag { Key = WorkflowTags.USER_ID_TAG, Value = UserId },
+                new Tag { Key = WorkflowTags.WORKFLOW_ID, Value = KeepWorkflow }
+            ]
+        });
+
+        s3Mock.Setup(s => s.ListObjectsV2Async(
+            It.Is<ListObjectsV2Request>(r => r.BucketName == Bucket),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new ListObjectsV2Response
+        {
+            S3Objects =
+            [
+                new() { Key = TriggerKey },
+                new() { Key = oldKey }
+            ],
+            IsTruncated = false
+        });
+
+        s3Mock.Setup(s => s.GetObjectTaggingAsync(
+            It.Is<GetObjectTaggingRequest>(r => r.Key == oldKey),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new GetObjectTaggingResponse
+        {
+            Tagging =
+            [
+                new Tag { Key = WorkflowTags.USER_ID_TAG, Value = UserId },
+                new Tag { Key = WorkflowTags.WORKFLOW_ID, Value = "wf1" }
+            ]
+        });
+
+        s3Mock.Setup(s => s.DeleteObjectsAsync(
+            It.IsAny<DeleteObjectsRequest>(),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new DeleteObjectsResponse
+        {
+            DeleteErrors =
+            [
+                new() { Key = oldKey, Code = "AccessDenied", Message = "denied" }
+            ]
+        });
+
+        // Act
+        await function.Handler(s3Event);
+
+        // Assert
+        loggerMock.VerifyLog(LogLevel.Warning, Times.Once(), nameof(Log.DeleteError));
+        loggerMock.VerifyLog(LogLevel.Information, Times.Once(), nameof(Log.CleanupCompleted));
+    }
+}

--- a/tests/SceneSplit.ObjectImageCleanerLambda.UnitTests/SceneSplit.ObjectImageCleanerLambda.UnitTests.csproj
+++ b/tests/SceneSplit.ObjectImageCleanerLambda.UnitTests/SceneSplit.ObjectImageCleanerLambda.UnitTests.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SceneSplit.Backend\SceneSplit.ObjectImageCleanerLambda\SceneSplit.ObjectImageCleanerLambda.csproj" />
+    <ProjectReference Include="..\SceneSplit.TestShared\SceneSplit.TestShared.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Introduces the ObjectImageCleanerLambda AWS Lambda function, infrastructure construct, configuration keys, and unit tests. The Lambda is triggered by S3 object creation events and cleans up old objects for a user, keeping only those from the current workflow. Updates the CDK stack to deploy the new Lambda, adds packaging steps, and registers the new projects in the solution.